### PR TITLE
enable main() function execution in generated code

### DIFF
--- a/USACOBench/evaluation/judges/usaco_utils.py
+++ b/USACOBench/evaluation/judges/usaco_utils.py
@@ -107,7 +107,14 @@ def check_correctness(program: str, test_num: int, timeout: float, memory_limit:
             check_program = prefix_program + program + suffix_program
 
             try:
-                exec_globals = {}
+                # Since we are executing untrusted code we want to remove all global
+                # variables from the namespace we provide to "exec" for running this code, but 
+                # we do want to set the {'__name__': '__main__'} so that "main" function
+                # in the generated code does get called (while all the global variables from
+                # the original context are still cleared out),
+                # We should consider replacing exec with subprocess so that the code
+                # is run in a separate Python interpreter process.
+                exec_globals = {'__name__': '__main__'}
                 with swallow_io():
                     with time_limit(timeout):
 # WARNING


### PR DESCRIPTION
Often times the generated code by a model contained `if __name__ == "__main__":` but none of this code was getting executed because the `exec_globals` being passed to `exec` in `unsafe_execute` was an empty dictionary so the built-in `__name__` global variable (like all global variables) did not exist anymore in the namespace for the generated code and hence the `main` function in the generated code never got called. The `main` function not getting called resulted in an empty `.pred` file (the file was created because the file open statement was added separately outside of the generated code's `main` function) and this resulted in the judge declaring that the answer to the unit test was wrong because it did not match the expected output (because it was comparing the empty prediction file contents with the ground truth file which was not empty).